### PR TITLE
Template selected by default

### DIFF
--- a/ozkour-front/src/components/ChoosingTemplate.vue
+++ b/ozkour-front/src/components/ChoosingTemplate.vue
@@ -54,6 +54,7 @@ const selected = ref('')
               :id="visual.id"
               name="template"
               :value="visual.value"
+              :checked="visual.id == 'quoide9'"
               class="radio-btn"
               v-model="selected"
             />


### PR DESCRIPTION
Le visuel sélectionné par défaut fonctionne (le Quoi de 9), le problème c'est qu'il ne prend pas en compte la valeur du visuel sélectionné, on ne voit pas la semaine sélectionnée automatiquement dans le calendrier.

J'ai ajouté dans l'input : 
`:checked="visual.id == 'quoide9'"`

J'ai également testé : 
`:checked="visual.value == 'Quoi de 9'"`

Mais le problème persiste.
