### PR TITLE
86 - makes the server runnable again

### DIFF
--- a/ozkour-back/config/routes/talk.js
+++ b/ozkour-back/config/routes/talk.js
@@ -1,7 +1,7 @@
 
 const { getTalkFromDate } = require('../../google-api/sheets')
 
-const { createSlides } = require('../../google-api/wrapperSlide')
+const { createSlides } = require('../../google-api/slideService')
 
 module.exports = [
   {

--- a/ozkour-back/index.js
+++ b/ozkour-back/index.js
@@ -27,8 +27,7 @@ const init = async () => {
   server.route(routes)
 
   await server.start()
-  // console.log(connect.auth());
-  // console.log('Server running on %s', server.info.uri);
+  console.log('Server running on %s', server.info.uri)
 }
 
 process.on('unhandledRejection', (err) => {
@@ -37,3 +36,36 @@ process.on('unhandledRejection', (err) => {
 })
 
 init()
+
+const initTest = async () => {
+  const port = '3001'
+
+  const server = Hapi.server({
+    port,
+    host: 'localhost',
+    routes: {
+      cors: {
+        origin: [process.env.ALLOWED_DOMAIN],
+        additionalHeaders: ['cache-control', 'x-requested-with']
+      }
+    },
+    query: {
+      parser: (query) => Qs.parse(query)
+    }
+  })
+
+  connect.auth()
+  server.route(routes)
+  await server.start()
+  await server.stop()
+  return true
+}
+
+process.on('unhandledRejection', (err) => {
+  console.log(err)
+  process.exit(1)
+})
+
+module.exports = {
+  initTest
+}

--- a/ozkour-back/tests/index.test.js
+++ b/ozkour-back/tests/index.test.js
@@ -1,0 +1,6 @@
+const index = require('../index')
+describe('index', () => {
+  it('should return true if the server started correctly', async () => {
+    expect(await index.initTest()).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Le server ne parvenait pas à se lancer correctement à cause d'un import dans une route. Le bug a été corriger et un test à été ajouter afin que cela ne se reproduise pas.

Pour tester, il suffit de lancer la commande npm run dev. Le serveur devrait se lancer et le message "Server running on http://localhost:3000" devrait apparaître (dépendant du .env "localhost" et "3000" peuvent être différent).

Pour le test rajouté, il y a peut-être une meilleur façon de faire.