### PR TITLE
122-ajouter un loader pour la récupération des talks

### DIFF
--- a/ozkour-front/src/components/EventArray.vue
+++ b/ozkour-front/src/components/EventArray.vue
@@ -1,5 +1,15 @@
 <template>
-  <h2 v-if="talks.retrieved == ''">
+  <div
+    v-if="talks.retreiving_talks"
+    class="loading-container"
+  >
+    <div class="loading">
+      <div class="spinner">
+        <div class="head" />
+      </div>
+    </div>
+  </div>
+  <h2 v-else-if="talks.retrieved == '' && !talks.retreiving_talks">
     Pas de talks entre les dates recherchées
   </h2>
   <div v-else>
@@ -178,4 +188,47 @@ export default {
   .arrow {
     @include arrow;
   }
+
+  .loading-container {
+  display:grid;
+  justify-content:center;
+  margin:1.5em;
+  left:48.5%;
+  top:50%;
+}
+
+.loading {
+  border-radius:50%;
+  width:3em;
+  height:3em;
+  transform-origin:center;
+  animation: rotate 1s linear infinite;
+}
+
+.spinner {
+  width: 4em;
+  height: 4em;
+  left: -1.1em;
+  top: -1.1em;
+
+  border-top: 1em solid #ffffffac;
+  position:relative;
+  border-right: 1em solid transparent;
+  border-radius: 50%;
+}
+
+.head {
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  margin-left: 3.45em;
+  margin-top: -0.37em;
+  background-color: #ffffffff;
+}
+
+@keyframes rotate{
+  to{
+    transform:rotate(360deg);
+  }
+}
 </style>

--- a/ozkour-front/src/components/EventArray.vue
+++ b/ozkour-front/src/components/EventArray.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="talks.retreiving_talks"
+    v-if="talks.retreivingTalks"
     class="loading-container"
   >
     <div class="loading">
@@ -9,7 +9,7 @@
       </div>
     </div>
   </div>
-  <h2 v-else-if="talks.retrieved == '' && !talks.retreiving_talks">
+  <h2 v-else-if="talks.retrieved == '' && !talks.retreivingTalks">
     Pas de talks entre les dates recherchées
   </h2>
   <div v-else>
@@ -190,45 +190,45 @@ export default {
   }
 
   .loading-container {
-  display:grid;
-  justify-content:center;
-  margin:1.5em;
-  left:48.5%;
-  top:50%;
-}
-
-.loading {
-  border-radius:50%;
-  width:3em;
-  height:3em;
-  transform-origin:center;
-  animation: rotate 1s linear infinite;
-}
-
-.spinner {
-  width: 4em;
-  height: 4em;
-  left: -1.1em;
-  top: -1.1em;
-
-  border-top: 1em solid #ffffffac;
-  position:relative;
-  border-right: 1em solid transparent;
-  border-radius: 50%;
-}
-
-.head {
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-  margin-left: 3.45em;
-  margin-top: -0.37em;
-  background-color: #ffffffff;
-}
-
-@keyframes rotate{
-  to{
-    transform:rotate(360deg);
+    display:grid;
+    justify-content:center;
+    margin:1.5em;
+    left:48.5%;
+    top:50%;
   }
-}
+
+  .loading {
+    border-radius:50%;
+    width:3em;
+    height:3em;
+    transform-origin:center;
+    animation: rotate 1s linear infinite;
+  }
+
+  .spinner {
+    width: 4em;
+    height: 4em;
+    left: -1.1em;
+    top: -1.1em;
+
+    border-top: 1em solid #ffffffac;
+    position:relative;
+    border-right: 1em solid transparent;
+    border-radius: 50%;
+  }
+
+  .head {
+    width: 1em;
+    height: 1em;
+    border-radius: 50%;
+    margin-left: 3.45em;
+    margin-top: -0.37em;
+    background-color: #ffffffff;
+  }
+
+  @keyframes rotate{
+    to{
+      transform:rotate(360deg);
+    }
+  }
 </style>

--- a/ozkour-front/src/stores/talks.js
+++ b/ozkour-front/src/stores/talks.js
@@ -8,7 +8,8 @@ export const useTalkStore = defineStore({
   state: () => ({
     retrieved: [],
     template: { name: '', frequency: '' },
-    date: {}
+    date: {},
+    retreiving_talks: false
   }),
   getters: {
     getSelectedTalks: (state) =>
@@ -54,6 +55,7 @@ export const useTalkStore = defineStore({
       }
     },
     async getTalks (dateStart, dateEnd) {
+      this.retreiving_talks = true
       const { data } = await api
         .get('/talk', {
           params: {
@@ -62,6 +64,8 @@ export const useTalkStore = defineStore({
           },
           paramsSerializer: (params) => qs.stringify(params, { encode: false })
         })
+
+      this.retreiving_talks = false
       this.updateTalks(data)
       this.selectedDate(dateStart, dateEnd)
     }

--- a/ozkour-front/src/stores/talks.js
+++ b/ozkour-front/src/stores/talks.js
@@ -9,7 +9,7 @@ export const useTalkStore = defineStore({
     retrieved: [],
     template: { name: '', frequency: '' },
     date: {},
-    retreiving_talks: false
+    retreivingTalks: false
   }),
   getters: {
     getSelectedTalks: (state) =>
@@ -55,19 +55,21 @@ export const useTalkStore = defineStore({
       }
     },
     async getTalks (dateStart, dateEnd) {
-      this.retreiving_talks = true
-      const { data } = await api
-        .get('/talk', {
-          params: {
-            start: dateStart.value,
-            end: dateEnd.value
-          },
-          paramsSerializer: (params) => qs.stringify(params, { encode: false })
-        })
-
-      this.retreiving_talks = false
-      this.updateTalks(data)
-      this.selectedDate(dateStart, dateEnd)
+      this.retreivingTalks = true
+      try {
+        const { data } = await api
+          .get('/talk', {
+            params: {
+              start: dateStart.value,
+              end: dateEnd.value
+            },
+            paramsSerializer: (params) => qs.stringify(params, { encode: false })
+          })
+        this.updateTalks(data)
+        this.selectedDate(dateStart, dateEnd)
+      } finally {
+        this.retreivingTalks = false
+      }
     }
   }
 })


### PR DESCRIPTION
Le problème est qu'on ne sait pas si l'appel vers le back a été pris en compte ou s'il n'y a pas de talks pendant la période.

Avec cette fonctionnalité, lorsque l'appel de récupération des talks est fait, un loader apparait. Puis, lorsqu'on récupérer le résultat de la requête, celui-ci disparait pour laisser place aux talks reçu ou au message "pas de talks dans la période"