### PR TITLE
137 changer le fonctionnement des créations de visuels talks

### DIFF
--- a/ozkour-back/src/domain/docsService.js
+++ b/ozkour-back/src/domain/docsService.js
@@ -8,7 +8,7 @@ class DocService {
   }
 
   async createEmailingDocs (talks) {
-    const talksByUniverses = emailingOrganizer.sortTalksEmailing(talks)
+    const { mapUniverse: talksByUniverses, allTalkComplete } = emailingOrganizer.sortTalksEmailing(talks)
     const { date: talkeDate } = talks[0]
     const year = dateUtils.getYear(talkeDate)
     const month = dateUtils.convDateToMonthInLetter(talkeDate)
@@ -22,10 +22,11 @@ class DocService {
       message: 'removed template text'
     })
     await this.docServiceRepository.addTextForEmailing(documentId, talksByUniverses)
+    const message = allTalkComplete ? 'Created !' : 'At least one talk is incomplete...'
     logger.verbose({
       message: 'add text for emailing document'
     })
-    return this.docServiceRepository.getSuccessMessage(documentId)
+    return this.docServiceRepository.getSuccessMessage(documentId, message)
   }
 }
 

--- a/ozkour-back/src/domain/emailingOrganizer.js
+++ b/ozkour-back/src/domain/emailingOrganizer.js
@@ -37,18 +37,12 @@ function verifyTalkEmailing (talks) {
     throw new Error('Can\'t create visual without talks')
   }
   return talks.every(
-    ({ date, universe, eventName, talkTitle, speakers }) => {
-      if (date === '') { date = undefined }
-      if (universe === '') { universe = undefined }
-      if (eventName === '') { eventName = undefined }
-      if (talkTitle === '') { talkTitle = undefined }
-      if (speakers === '') { speakers = undefined }
-      return Boolean(date) &&
+    ({ date, universe, eventName, talkTitle, speakers }) =>
+      Boolean(date) &&
       Boolean(universe) &&
       Boolean(eventName) &&
       Boolean(talkTitle) &&
       Boolean(speakers)
-    }
   )
 }
 module.exports = {

--- a/ozkour-back/src/domain/emailingOrganizer.js
+++ b/ozkour-back/src/domain/emailingOrganizer.js
@@ -12,6 +12,7 @@ function sortTalksEmailing (data) {
   }
   const mapUniverse = new Map()
   talks.forEach(talk => {
+    const thisTalkIsComplete = (!!talk.date && !!talk.eventType && !!talk.eventName && !!talk.talkTitle && !!talk.speakers)
     const newTalk = {
       date: talk.date,
       eventType: talk.eventType,
@@ -19,7 +20,7 @@ function sortTalksEmailing (data) {
       talkTitle: talk.talkTitle,
       speakers: talk.speakers,
       link: talk.link,
-      complete: (allTalkComplete || (!!talk.date && !!talk.eventType && !!talk.eventName && !!talk.talkTitle && !!talk.speakers))
+      complete: (allTalkComplete || thisTalkIsComplete)
     }
     if (!mapUniverse.has(talk.universe)) {
       mapUniverse.set(talk.universe, [newTalk])

--- a/ozkour-back/src/domain/emailingOrganizer.js
+++ b/ozkour-back/src/domain/emailingOrganizer.js
@@ -6,7 +6,8 @@ function sortTalksEmailing (data) {
     message: `talks recieved : \n${talks.map(talk => ' ' + talk.toString()).join('\n')}`
   })
 
-  if (!verifyTalkEmailing(talks)) {
+  const allTalkComplete = verifyTalkEmailing(data)
+  if (!allTalkComplete) {
     throw (new Error('wrong format of talk for Emailing'))
   }
   const mapUniverse = new Map()
@@ -17,7 +18,8 @@ function sortTalksEmailing (data) {
       eventName: talk.eventName,
       talkTitle: talk.talkTitle,
       speakers: talk.speakers,
-      link: talk.link
+      link: talk.link,
+      complete: (allTalkComplete || (!!talk.date && !!talk.eventType && !!talk.eventName && !!talk.talkTitle && !!talk.speakers))
     }
     if (!mapUniverse.has(talk.universe)) {
       mapUniverse.set(talk.universe, [newTalk])
@@ -31,15 +33,21 @@ function sortTalksEmailing (data) {
 
 function verifyTalkEmailing (talks) {
   if (!Array.isArray(talks) || talks.length <= 0) {
-    return false
+    throw new Error('Can\'t create visual without talks')
   }
   return talks.every(
-    ({ date, universe, eventName, talkTitle, speakers }) =>
-      Boolean(date) &&
+    ({ date, universe, eventName, talkTitle, speakers }) => {
+      if (date === '') { date = undefined }
+      if (universe === '') { universe = undefined }
+      if (eventName === '') { eventName = undefined }
+      if (talkTitle === '') { talkTitle = undefined }
+      if (speakers === '') { speakers = undefined }
+      return Boolean(date) &&
       Boolean(universe) &&
       Boolean(eventName) &&
       Boolean(talkTitle) &&
       Boolean(speakers)
+    }
   )
 }
 module.exports = {

--- a/ozkour-back/src/domain/emailingOrganizer.js
+++ b/ozkour-back/src/domain/emailingOrganizer.js
@@ -28,7 +28,7 @@ function sortTalksEmailing (data) {
       newValue.push(newTalk)
     }
   })
-  return mapUniverse
+  return { mapUniverse, allTalkComplete }
 }
 
 function verifyTalkEmailing (talks) {

--- a/ozkour-back/src/domain/model/talk.js
+++ b/ozkour-back/src/domain/model/talk.js
@@ -1,5 +1,5 @@
 class Talk {
-  constructor ({ date, universe, eventType, eventName, talkTitle, speakers, link, checked = true }) {
+  constructor ({ date, universe, eventType, eventName, talkTitle, speakers, link, checked = true, complete = false }) {
     this.date = date
     this.universe = universe
     this.eventType = eventType
@@ -8,6 +8,7 @@ class Talk {
     this.speakers = speakers
     this.link = link
     this.checked = checked
+    this.complete = complete
   }
 
   toString () {

--- a/ozkour-back/src/infrastructure/googledocs/googleDocRepository.js
+++ b/ozkour-back/src/infrastructure/googledocs/googleDocRepository.js
@@ -18,9 +18,9 @@ function removeTemplateText (documentId) {
   }
 }
 
-function getSuccessMessage (documentId) {
+function getSuccessMessage (documentId, message) {
   return {
-    message: 'Created !',
+    message,
     link:
         'https://docs.google.com/document/d/' +
         documentId +

--- a/ozkour-back/src/infrastructure/googledocs/googleDocRepository.js
+++ b/ozkour-back/src/infrastructure/googledocs/googleDocRepository.js
@@ -42,7 +42,7 @@ function addTitle (title, index) {
     {
       updateParagraphStyle: {
         paragraphStyle: {
-          namedStyleType: 'HEADING_1'
+          namedStyleType: title === 'Sans Univers' ? 'HEADING_2' : 'HEADING_1'
         },
         fields: 'namedStyleType',
         range: {
@@ -55,8 +55,9 @@ function addTitle (title, index) {
   return requests
 }
 
-function addTalkInEmailing (index, titleTalk, speakers, date, eventName, url) {
-  const line = `${titleTalk}, animé par ${speakers}, le ${date} | ${eventName}` + '\n\n'
+function addTalkInEmailing (index, talk) {
+  const { talkTitle, speakers, date, eventName, url } = talk
+  const line = `${talkTitle}, animé par ${speakers}, le ${date} | ${eventName}` + '\n\n'
   const end = index + (line.length)
   const request = [
     {
@@ -70,7 +71,7 @@ function addTalkInEmailing (index, titleTalk, speakers, date, eventName, url) {
     {
       updateParagraphStyle: {
         paragraphStyle: {
-          namedStyleType: 'NORMAL_TEXT'
+          namedStyleType: talk.complete ? 'NORMAL_TEXT' : 'SUBTITLE'
         },
         fields: 'namedStyleType',
         range: {
@@ -92,7 +93,7 @@ function addTalkInEmailing (index, titleTalk, speakers, date, eventName, url) {
         fields: 'link',
         range: {
           startIndex: index,
-          endIndex: index + titleTalk.length
+          endIndex: index + talkTitle.length
         }
       }
     })
@@ -104,15 +105,12 @@ async function addTextForEmailing (documentId, mapUniverse) {
   const requests = []
   let index = 1
   mapUniverse.forEach((talksForUniverse, universe) => {
+    if (universe === '') { universe = 'Sans Univers' }
     requests.push(addTitle(universe, index))
     index += universe.length + 1
     talksForUniverse.forEach(talk => {
       requests.push(addTalkInEmailing(index,
-        talk.talkTitle,
-        talk.speakers,
-        talk.date,
-        talk.eventName,
-        talk.link
+        talk
       ))
       const line = `${talk.talkTitle}, animé par ${talk.speakers}, le ${talk.date} | ${talk.eventName}` + '\n'
       index += line.length + 1

--- a/ozkour-back/tests/unit/__snapshots__/docs.test.js.snap
+++ b/ozkour-back/tests/unit/__snapshots__/docs.test.js.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Docs creation should return a JSON request to add a talk to the doc in red when the talk is incomplete 1`] = `
+Array [
+  Object {
+    "insertText": Object {
+      "location": Object {
+        "index": 10,
+      },
+      "text": "Title, animé par , le 11/03/2021 | eventName
+
+",
+    },
+  },
+  Object {
+    "updateParagraphStyle": Object {
+      "fields": "namedStyleType",
+      "paragraphStyle": Object {
+        "namedStyleType": "SUBTITLE",
+      },
+      "range": Object {
+        "endIndex": 56,
+        "startIndex": 10,
+      },
+    },
+  },
+  Object {
+    "updateTextStyle": Object {
+      "fields": "link",
+      "range": Object {
+        "endIndex": 15,
+        "startIndex": 10,
+      },
+      "textStyle": Object {
+        "link": Object {
+          "url": "https://example.com",
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`Docs creation should return a JSON request to add a talk to the doc with url 1`] = `
 Array [
   Object {
@@ -62,6 +103,32 @@ Array [
       "range": Object {
         "endIndex": 63,
         "startIndex": 10,
+      },
+    },
+  },
+]
+`;
+
+exports[`Docs creation should return a JSON request to add a title in red to a document when the title is "Sans Univers" 1`] = `
+Array [
+  Object {
+    "insertText": Object {
+      "location": Object {
+        "index": 1,
+      },
+      "text": "Sans Univers
+",
+    },
+  },
+  Object {
+    "updateParagraphStyle": Object {
+      "fields": "namedStyleType",
+      "paragraphStyle": Object {
+        "namedStyleType": "HEADING_2",
+      },
+      "range": Object {
+        "endIndex": 13,
+        "startIndex": 1,
       },
     },
   },

--- a/ozkour-back/tests/unit/docs.test.js
+++ b/ozkour-back/tests/unit/docs.test.js
@@ -50,20 +50,15 @@ describe('Verify data emailing', () => {
     it('should return an error if parameter is an array with zero element', () => {
       const array = []
       // then
-      try {
-        emailingOrganizer.verifyTalkEmailing(array)
-      } catch (e) {
-        expect('' + e).toBe('Error: Can\'t create visual without talks')
-      }
+      const error = () => emailingOrganizer.verifyTalkEmailing(array)
+      expect(error).toThrow('Can\'t create visual without talks')
     })
     it('should return false if the talks are undefined', () => {
       const notArray = undefined
+      // when
+      const error = () => emailingOrganizer.verifyTalkEmailing(notArray)
       // then
-      try {
-        emailingOrganizer.verifyTalkEmailing(notArray)
-      } catch (e) {
-        expect('' + e).toBe('Error: Can\'t create visual without talks')
-      }
+      expect(error).toThrow('Can\'t create visual without talks')
     })
   })
 })

--- a/ozkour-back/tests/unit/docs.test.js
+++ b/ozkour-back/tests/unit/docs.test.js
@@ -45,29 +45,25 @@ describe('Verify data emailing', () => {
       // then
       expect(emailingOrganizer.verifyTalkEmailing(array)).toBe(true)
     })
-    it('should return false if parameter is an array with zero element', () => {
+  })
+  describe('the talks are not in a valid array', () => {
+    it('should return an error if parameter is an array with zero element', () => {
       const array = []
       // then
-      expect(emailingOrganizer.verifyTalkEmailing(array)).toBe(false)
+      try {
+        emailingOrganizer.verifyTalkEmailing(array)
+      } catch (e) {
+        expect('' + e).toBe('Error: Can\'t create visual without talks')
+      }
     })
-  })
-  describe('the talks are not in an array', () => {
-    describe('the talks is a String', () => {
-      it('should return false', () => {
-        // given
-        const notArray = 'This is not an array'
-        // when
-        const isNotAnArray = emailingOrganizer.verifyTalkEmailing(notArray)
-        // then
-        expect(isNotAnArray).toBe(false)
-      })
-    })
-    describe('the talks are undefined', () => {
-      it('should return false', () => {
-        const notArray = undefined
-        // then
-        expect(emailingOrganizer.verifyTalkEmailing(notArray)).toBe(false)
-      })
+    it('should return false if the talks are undefined', () => {
+      const notArray = undefined
+      // then
+      try {
+        emailingOrganizer.verifyTalkEmailing(notArray)
+      } catch (e) {
+        expect('' + e).toBe('Error: Can\'t create visual without talks')
+      }
     })
   })
 })
@@ -85,25 +81,30 @@ describe('Docs creation', () => {
   it('should return a JSON request to add a talk to the doc without url', () => {
     // given
     const index = 10
-    const titleTalk = 'Title'
-    const speakers = 'speaker'
-    const date = '11/03/2021'
-    const eventName = 'eventName'
+    const newTalk = {
+      date: '11/03/2021',
+      eventName: 'eventName',
+      talkTitle: 'Title',
+      speakers: 'speaker'
+    }
     // when
-    const addTalksRequest = googleDocRepository.addTalkInEmailing(index, titleTalk, speakers, date, eventName)
+    const addTalksRequest = googleDocRepository.addTalkInEmailing(index, newTalk)
     // then
     expect(addTalksRequest).toMatchSnapshot()
   })
   it('should return a JSON request to add a talk to the doc with url', () => {
     // given
     const index = 10
-    const titleTalk = 'Title'
-    const speakers = 'speaker'
-    const date = '11/03/2021'
-    const eventName = 'eventName'
-    const url = 'https://example.com'
+    const newTalk = {
+      date: '11/03/2021',
+      eventName: 'eventName',
+      talkTitle: 'Title',
+      speakers: 'speaker',
+      url: 'https://example.com'
+    }
+
     // when
-    const addTalksRequest = googleDocRepository.addTalkInEmailing(index, titleTalk, speakers, date, eventName, url)
+    const addTalksRequest = googleDocRepository.addTalkInEmailing(index, newTalk)
     // then
     expect(addTalksRequest).toMatchSnapshot()
   })

--- a/ozkour-back/tests/unit/docs.test.js
+++ b/ozkour-back/tests/unit/docs.test.js
@@ -85,7 +85,8 @@ describe('Docs creation', () => {
       date: '11/03/2021',
       eventName: 'eventName',
       talkTitle: 'Title',
-      speakers: 'speaker'
+      speakers: 'speaker',
+      complete: true
     }
     // when
     const addTalksRequest = googleDocRepository.addTalkInEmailing(index, newTalk)
@@ -100,7 +101,34 @@ describe('Docs creation', () => {
       eventName: 'eventName',
       talkTitle: 'Title',
       speakers: 'speaker',
-      url: 'https://example.com'
+      url: 'https://example.com',
+      complete: true
+    }
+
+    // when
+    const addTalksRequest = googleDocRepository.addTalkInEmailing(index, newTalk)
+    // then
+    expect(addTalksRequest).toMatchSnapshot()
+  })
+  it('should return a JSON request to add a title in red to a document when the title is "Sans Univers"', () => {
+    // given
+    const title = 'Sans Univers'
+    const index = 1
+    // when
+    const addTitleRequest = googleDocRepository.addTitle(title, index)
+    // then
+    expect(addTitleRequest).toMatchSnapshot()
+  })
+  it('should return a JSON request to add a talk to the doc in red when the talk is incomplete', () => {
+    // given
+    const index = 10
+    const newTalk = {
+      date: '11/03/2021',
+      eventName: 'eventName',
+      talkTitle: 'Title',
+      speakers: '',
+      url: 'https://example.com',
+      complete: false
     }
 
     // when

--- a/ozkour-front/package-lock.json
+++ b/ozkour-front/package-lock.json
@@ -6596,9 +6596,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+      "version": "1.0.30001423",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
+      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
       "dev": true,
       "funding": [
         {
@@ -26274,9 +26274,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+      "version": "1.0.30001423",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
+      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/ozkour-front/src/components/PopUp.vue
+++ b/ozkour-front/src/components/PopUp.vue
@@ -1,0 +1,140 @@
+<script>
+import PrimaryBtn from '@/components/Buttons/PrimaryBtn.vue'
+
+export default {
+  components: {
+    PrimaryBtn
+  },
+  props: {
+    message: {
+      type: String,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ['close'],
+  expose: ['reset']
+}
+</script>
+
+<template>
+  <div class="popup-bg">
+    <div class="popup-header">
+      <button
+        type="button"
+        class="close-btn"
+        @click="$emit('close')"
+      >
+        X
+      </button>
+      <h2>{{ title }}</h2>
+    </div>
+
+    <div class="recap">
+      <div class="recap-details" />
+      <p class="text-pop-up">
+        {{ message }}
+      </p>
+    </div>
+    <div class="validate">
+      <PrimaryBtn
+        @click="$emit('close')"
+      >
+        OK
+      </PrimaryBtn>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+.popup-bg {
+  @include popup-bg;
+}
+
+.popup-header {
+  @include popup-header;
+}
+
+.close-btn {
+  @include body;
+  @include popup-close-button;
+}
+
+.recap {
+  color: black;
+  padding: 0px 20px;
+}
+
+.icon-bg {
+  @include popup-icon-bg;
+}
+
+.icon {
+  width: 20px;
+}
+
+.recap-details {
+  @include popup-summary;
+}
+
+.text-pop-up {
+  text-align: center;
+}
+
+.events {
+  margin: 0px;
+  padding-left: 60px;
+}
+
+.validate {
+  display: flex;
+  justify-content: center;
+  padding: 30px 0px;
+}
+
+.loading-container {
+  display:grid;
+  justify-content:center;
+  position:fixed;
+  left:48.5%;
+  top:50%;
+}
+
+.loading {
+  border-radius:50%;
+  width:2.5em;
+  height:2.5em;
+  transform-origin:center;
+  animation: rotate 1s linear infinite;
+}
+
+.spinner {
+  width: 7em;
+  height: 7em;
+  left: -2.8em;
+  top: -2.8em;
+  border-top: 1em solid #C21E65;
+  position:relative;
+  border-right: 1em solid transparent;
+  border-radius: 50%;
+}
+
+.head {
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  margin-left: 5.9em;
+  margin-top: -0.05em;
+  background: linear-gradient(-25deg, #EE2238 0%, #C21E65 100%);
+}
+
+@keyframes rotate{
+  to{
+    transform:rotate(360deg);
+  }
+}
+</style>

--- a/ozkour-front/src/components/PopUp.vue
+++ b/ozkour-front/src/components/PopUp.vue
@@ -33,9 +33,9 @@ export default {
       <h2>{{ title }}</h2>
     </div>
 
-    <div class="recap">
-      <div class="recap-details" />
-      <p class="text-pop-up">
+    <div class="message">
+      <div class="message-details" />
+      <p class="message-pop-up">
         {{ message }}
       </p>
     </div>
@@ -69,14 +69,6 @@ export default {
   padding: 0px 20px;
 }
 
-.icon-bg {
-  @include popup-icon-bg;
-}
-
-.icon {
-  width: 20px;
-}
-
 .recap-details {
   @include popup-summary;
 }
@@ -85,56 +77,10 @@ export default {
   text-align: center;
 }
 
-.events {
-  margin: 0px;
-  padding-left: 60px;
-}
-
 .validate {
   display: flex;
   justify-content: center;
   padding: 30px 0px;
 }
 
-.loading-container {
-  display:grid;
-  justify-content:center;
-  position:fixed;
-  left:48.5%;
-  top:50%;
-}
-
-.loading {
-  border-radius:50%;
-  width:2.5em;
-  height:2.5em;
-  transform-origin:center;
-  animation: rotate 1s linear infinite;
-}
-
-.spinner {
-  width: 7em;
-  height: 7em;
-  left: -2.8em;
-  top: -2.8em;
-  border-top: 1em solid #C21E65;
-  position:relative;
-  border-right: 1em solid transparent;
-  border-radius: 50%;
-}
-
-.head {
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-  margin-left: 5.9em;
-  margin-top: -0.05em;
-  background: linear-gradient(-25deg, #EE2238 0%, #C21E65 100%);
-}
-
-@keyframes rotate{
-  to{
-    transform:rotate(360deg);
-  }
-}
 </style>

--- a/ozkour-front/src/components/RecapModal.vue
+++ b/ozkour-front/src/components/RecapModal.vue
@@ -90,7 +90,7 @@ export default {
             :key="talk"
             data-test="talk-title"
           >
-            {{ talk.talkTitle }}
+            {{ talk.talkTitle?talk.talkTitle:"non renseigné" }}
           </li>
         </ul>
       </div>

--- a/ozkour-front/src/components/RecapModal.vue
+++ b/ozkour-front/src/components/RecapModal.vue
@@ -160,46 +160,4 @@ export default {
   justify-content: center;
   padding: 30px 0px;
 }
-
-.loading-container {
-  display:grid;
-  justify-content:center;
-  position:fixed;
-  left:48.5%;
-  top:50%;
-}
-
-.loading {
-  border-radius:50%;
-  width:2.5em;
-  height:2.5em;
-  transform-origin:center;
-  animation: rotate 1s linear infinite;
-}
-
-.spinner {
-  width: 7em;
-  height: 7em;
-  left: -2.8em;
-  top: -2.8em;
-  border-top: 1em solid #C21E65;
-  position:relative;
-  border-right: 1em solid transparent;
-  border-radius: 50%;
-}
-
-.head {
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-  margin-left: 5.9em;
-  margin-top: -0.05em;
-  background: linear-gradient(-25deg, #EE2238 0%, #C21E65 100%);
-}
-
-@keyframes rotate{
-  to{
-    transform:rotate(360deg);
-  }
-}
 </style>

--- a/ozkour-front/src/stores/talks.js
+++ b/ozkour-front/src/stores/talks.js
@@ -42,16 +42,16 @@ export const useTalkStore = defineStore({
       case 'QuoiDeNeuf': {
         const { data } = await api
           .post('/talk/quoiDeNeuf', this.getSelectedTalks)
-        return data.link
+        return { link: data.link, message: data.message }
       }
       case 'E-mailing': {
         const { data } = await api
           .post('/talk/emailing', this.getSelectedTalks)
-        return data.link
+        return { link: data.link, message: data.message }
       }
       default:
         console.error('template :"', this.template.name, "\" n'est pas reconnu")
-        return '/'
+        return { link: '/', message: 'unknown template' }
       }
     },
     async getTalks (dateStart, dateEnd) {

--- a/ozkour-front/src/views/TalkForm.vue
+++ b/ozkour-front/src/views/TalkForm.vue
@@ -5,6 +5,7 @@ import PrimaryBtn from '@/components/Buttons/PrimaryBtn.vue'
 import EventArray from '@/components/EventArray.vue'
 import RecapModal from '@/components/RecapModal.vue'
 import { useTalkStore } from '@/stores/talks'
+import PopUp from '../components/PopUp.vue'
 
 export default {
   components: {
@@ -12,10 +13,13 @@ export default {
     ChoosingDate,
     PrimaryBtn,
     EventArray,
-    RecapModal
+    RecapModal,
+    PopUp
   },
   data () {
     return {
+      replyMessage: '',
+      isPopUpVisible: false,
       isModalVisible: false,
       isSlidesGenerationFailed: false,
       isGetTalksFailed: false,
@@ -28,6 +32,8 @@ export default {
         const { link, message } = await this.talks.generateSlidesForSelectedTalks()
         console.log(message)
         window.open(link, '_blank')
+        this.replyMessage = message
+        this.showPopUp()
       } catch (e) {
         this.isSlidesGenerationFailed = true
       }
@@ -47,6 +53,13 @@ export default {
     closeModal () {
       this.isModalVisible = false
     },
+    showPopUp () {
+      this.isPopUpVisible = true
+    },
+    closePopUp () {
+      this.replyMessage = ''
+      this.isPopUpVisible = false
+    },
     closeErrorMessage () {
       this.isSlidesGenerationFailed = false
     }
@@ -56,7 +69,7 @@ export default {
 
 <template>
   <main
-    :class="{ 'container--blured': isModalVisible }"
+    :class="{ 'container--blured': isModalVisible || isPopUpVisible}"
     class="container"
   >
     <h1 class="container__title">
@@ -99,11 +112,20 @@ export default {
     <RecapModal
       v-if="isModalVisible"
       id="talk-recap-modal"
+      class="non-blurable"
       :talks="talks.getSelectedTalks"
       :template="talks.template.name"
       :dates="talks.date"
       @submit="onRecapSubmit"
       @close="closeModal"
+    />
+    <PopUp
+      v-if="isPopUpVisible"
+      id="talk-popup-modal"
+      class="non-blurable"
+      :message="replyMessage"
+      :title="'Résultat'"
+      @close="closePopUp"
     />
   </main>
 </template>
@@ -113,7 +135,7 @@ export default {
 .container {
   @include form-container;
 
-  &--blured > :not(#talk-recap-modal) {
+  &--blured > :not(.non-blurable) {
     filter: blur(5px);
   }
 

--- a/ozkour-front/src/views/TalkForm.vue
+++ b/ozkour-front/src/views/TalkForm.vue
@@ -25,7 +25,8 @@ export default {
   methods: {
     async onRecapSubmit () {
       try {
-        const link = await this.talks.generateSlidesForSelectedTalks()
+        const { link, message } = await this.talks.generateSlidesForSelectedTalks()
+        console.log(message)
         window.open(link, '_blank')
       } catch (e) {
         this.isSlidesGenerationFailed = true

--- a/ozkour-front/tests/unit/TestStore.spec.js
+++ b/ozkour-front/tests/unit/TestStore.spec.js
@@ -1,148 +1,148 @@
-import { api } from "@/api/apiConfig";
-import { setActivePinia, createPinia } from "pinia";
+import { api } from '@/api/apiConfig'
+import { setActivePinia, createPinia } from 'pinia'
 
-import { useTalkStore } from "../../src/stores/talks";
+import { useTalkStore } from '../../src/stores/talks'
 
-jest.mock("@/api/apiConfig");
+jest.mock('@/api/apiConfig')
 
-describe("Talk Store", () => {
+describe('Talk Store', () => {
   beforeEach(() => {
-    setActivePinia(createPinia());
+    setActivePinia(createPinia())
   })
 
-  it("updateTalks", () => {
-    const talk = useTalkStore();
-    expect(talk.retrieved.length).toBe(0);
-    talk.updateTalks(talksRetrieved);
-    expect(talk.retrieved.length).toBe(5);
+  it('updateTalks', () => {
+    const talk = useTalkStore()
+    expect(talk.retrieved.length).toBe(0)
+    talk.updateTalks(talksRetrieved)
+    expect(talk.retrieved.length).toBe(5)
   })
 
-  it("getSelectedTalks give all talks by default ", () => {
-    const talk = useTalkStore();
-    expect(talk.retrieved.length).toBe(0);
-    talk.updateTalks(talksRetrieved);
-    expect(talk.getSelectedTalks.length).toBe(5);
+  it('getSelectedTalks give all talks by default ', () => {
+    const talk = useTalkStore()
+    expect(talk.retrieved.length).toBe(0)
+    talk.updateTalks(talksRetrieved)
+    expect(talk.getSelectedTalks.length).toBe(5)
   })
 
-  it("uncheckTalk", () => {
-    const talk = useTalkStore();
-    talk.updateTalks(talksRetrieved);
+  it('uncheckTalk', () => {
+    const talk = useTalkStore()
+    talk.updateTalks(talksRetrieved)
 
     const talkToBeRemoved = {
-      date: "19/01/2021",
-      universe: "",
-      eventType: "Meetup",
-      eventName: "GraalVM Night",
-      talkTitle: "GraalVM for Sustainable Software Development?",
-      speakers: "Adrien Nortain",
-    };
+      date: '19/01/2021',
+      universe: '',
+      eventType: 'Meetup',
+      eventName: 'GraalVM Night',
+      talkTitle: 'GraalVM for Sustainable Software Development?',
+      speakers: 'Adrien Nortain'
+    }
 
-    talk.uncheckTalk(talkToBeRemoved);
-    expect(talk.getSelectedTalks.length).toBe(4);
-    expect(talk.retrieved.length).toBe(5);
+    talk.uncheckTalk(talkToBeRemoved)
+    expect(talk.getSelectedTalks.length).toBe(4)
+    expect(talk.retrieved.length).toBe(5)
   })
 
-  it("addCheckedTalk", () => {
-    const talk = useTalkStore();
-    talk.updateTalks(talksRetrieved);
+  it('addCheckedTalk', () => {
+    const talk = useTalkStore()
+    talk.updateTalks(talksRetrieved)
 
     const talkToBeRemovedAndAdded = {
-      date: "19/01/2021",
-      universe: "",
-      eventType: "Meetup",
-      eventName: "GraalVM Night",
-      talkTitle: "GraalVM for Sustainable Software Development?",
-      speakers: "Adrien Nortain",
-    };
+      date: '19/01/2021',
+      universe: '',
+      eventType: 'Meetup',
+      eventName: 'GraalVM Night',
+      talkTitle: 'GraalVM for Sustainable Software Development?',
+      speakers: 'Adrien Nortain'
+    }
 
-    talk.uncheckTalk(talkToBeRemovedAndAdded);
-    talk.checkTalk(talkToBeRemovedAndAdded);
-    expect(talk.getSelectedTalks.length).toBe(5);
-    expect(talk.retrieved.length).toBe(5);
+    talk.uncheckTalk(talkToBeRemovedAndAdded)
+    talk.checkTalk(talkToBeRemovedAndAdded)
+    expect(talk.getSelectedTalks.length).toBe(5)
+    expect(talk.retrieved.length).toBe(5)
   })
 
-  it("addCheckedTalk order", () => {
-    const talk = useTalkStore();
-    talk.updateTalks(talksRetrieved);
+  it('addCheckedTalk order', () => {
+    const talk = useTalkStore()
+    talk.updateTalks(talksRetrieved)
 
     const talkToBeRemovedAndAdded = {
-      date: "19/01/2021",
-      universe: "",
-      eventType: "Meetup",
-      eventName: "GraalVM Night",
-      talkTitle: "GraalVM for Sustainable Software Development?",
-      speakers: "John Doe",
+      date: '19/01/2021',
+      universe: '',
+      eventType: 'Meetup',
+      eventName: 'GraalVM Night',
+      talkTitle: 'GraalVM for Sustainable Software Development?',
+      speakers: 'John Doe',
       checked: true
-    };
+    }
 
-    talk.uncheckTalk(talkToBeRemovedAndAdded);
-    talk.checkTalk(talkToBeRemovedAndAdded);
-    expect(talk.getSelectedTalks[0]).toStrictEqual(talkToBeRemovedAndAdded);
+    talk.uncheckTalk(talkToBeRemovedAndAdded)
+    talk.checkTalk(talkToBeRemovedAndAdded)
+    expect(talk.getSelectedTalks[0]).toStrictEqual(talkToBeRemovedAndAdded)
   })
 
-  describe("generateSlidesForSelectedTalks action", () => {
+  describe('generateSlidesForSelectedTalks action', () => {
     it('should return the slide\'s link given status code to be 200', async () => {
-      const talk = useTalkStore();
+      const talk = useTalkStore()
 
-      talk.updateTalks(talksRetrieved);
+      talk.updateTalks(talksRetrieved)
       talk.pickedTemplate('QuoiDeNeuf', 'week')
 
       api.post.mockResolvedValueOnce({
         data: {
-          link : 'https://monliendeslide.com'
-        } 
+          link: 'https://monliendeslide.com'
+        }
       })
-      const link = await talk.generateSlidesForSelectedTalks(talksRetrieved);
+      const res = await talk.generateSlidesForSelectedTalks(talksRetrieved)
 
-      expect(link).toBe('https://monliendeslide.com')
+      expect(res.link).toBe('https://monliendeslide.com')
     })
   })
-});
+})
 
 const talksRetrieved = [
   {
-    date: "19/01/2021",
-    universe: "",
-    eventType: "Meetup",
-    eventName: "GraalVM Night",
-    talkTitle: "GraalVM for Sustainable Software Development?",
-    speakers: "John Doe",
+    date: '19/01/2021',
+    universe: '',
+    eventType: 'Meetup',
+    eventName: 'GraalVM Night',
+    talkTitle: 'GraalVM for Sustainable Software Development?',
+    speakers: 'John Doe',
     checked: true
   },
   {
-    date: "19/01/2021",
-    universe: "",
-    eventType: "NightClazz",
-    eventName: "NightClass",
-    talkTitle: "Migration JS vers TS sur du react",
-    speakers: "John Doe",
+    date: '19/01/2021',
+    universe: '',
+    eventType: 'NightClazz',
+    eventName: 'NightClass',
+    talkTitle: 'Migration JS vers TS sur du react',
+    speakers: 'John Doe',
     checked: true
   },
   {
-    date: "21/01/2021",
-    universe: "",
-    eventType: "Meetup",
-    eventName: "Nantes JS #55",
-    talkTitle: "Nuxt 2021",
-    speakers: "John Doe",
+    date: '21/01/2021',
+    universe: '',
+    eventType: 'Meetup',
+    eventName: 'Nantes JS #55',
+    talkTitle: 'Nuxt 2021',
+    speakers: 'John Doe',
     checked: true
   },
   {
-    date: "21/01/2021",
-    universe: "",
-    eventType: "Autre",
-    eventName: "Webinar Strigo",
-    talkTitle: "Simplify Remote Hands-On Training and Improve Engagement",
-    speakers: "John Doe",
+    date: '21/01/2021',
+    universe: '',
+    eventType: 'Autre',
+    eventName: 'Webinar Strigo',
+    talkTitle: 'Simplify Remote Hands-On Training and Improve Engagement',
+    speakers: 'John Doe',
     checked: true
   },
   {
-    date: "25/01/2021",
-    universe: "",
-    eventType: "NightClazz",
-    eventName: "RemoteClazz Nodejs",
-    talkTitle: "Techniques minimalistes pour Node.js",
-    speakers: "John Doe",
+    date: '25/01/2021',
+    universe: '',
+    eventType: 'NightClazz',
+    eventName: 'RemoteClazz Nodejs',
+    talkTitle: 'Techniques minimalistes pour Node.js',
+    speakers: 'John Doe',
     checked: true
-  },
-];
+  }
+]

--- a/ozkour-front/tests/unit/TestTalkForm.spec.js
+++ b/ozkour-front/tests/unit/TestTalkForm.spec.js
@@ -1,46 +1,46 @@
-import { mount } from "@vue/test-utils";
-import { createTestingPinia } from "@pinia/testing";
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
 
-import TalkForm from '@/views/TalkForm';
+import TalkForm from '@/views/TalkForm'
 
-describe("TalkForm component",  () => {
+describe('TalkForm component', () => {
   const _buildTalkForm = (options = {}) => {
-    const { data } = options;
+    const { data } = options
 
     return mount(TalkForm, {
-      shallow  : true,
-      data() {
+      shallow: true,
+      data () {
         return data
       },
       global: {
-        plugins: [createTestingPinia()],
-      },
+        plugins: [createTestingPinia()]
+      }
     })
-  };
+  }
 
-  describe("Recap modal behavior", () => {
-    describe("When the component is mounted", () => {
+  describe('Recap modal behavior', () => {
+    describe('When the component is mounted', () => {
       it('should hide the modal', () => {
-        const talkForm = _buildTalkForm();
-  
+        const talkForm = _buildTalkForm()
+
         expect(talkForm.find('#talk-recap-modal').exists()).toBe(false)
       })
     })
 
     it('should display the modal when the generate button is clicked', async () => {
-      const talkForm = _buildTalkForm();
+      const talkForm = _buildTalkForm()
 
-      await talkForm.find('primary-btn-stub').trigger('click');
+      await talkForm.find('primary-btn-stub').trigger('click')
 
-      expect(talkForm.find('#talk-recap-modal')).toBeTruthy();
+      expect(talkForm.find('#talk-recap-modal')).toBeTruthy()
     })
 
     it('should hide the modal when the Modal component emit a close event', async () => {
-      const talkForm = _buildTalkForm({data : {isModalVisible : true}});
+      const talkForm = _buildTalkForm({ data: { isModalVisible: true } })
 
-      await talkForm.find('#talk-recap-modal').trigger('close');
+      await talkForm.find('#talk-recap-modal').trigger('close')
 
-      expect(talkForm.find('#talk-recap-modal').exists()).toBe(false);
+      expect(talkForm.find('#talk-recap-modal').exists()).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Le service marketing a demandé qu'il soit possible de générer des visuels avec des talks incomplets. Toutefois ces talks doivent se démarquer visuellement des autres.
Il doit également y avoir un message sur l'application pour indiquer que des talks ne sont pas complets sur le visuel généré.

Ne doit fonctionner seulement sur les visuels emailing